### PR TITLE
Add basic MCP Client console app

### DIFF
--- a/MCPClientApp/MCPClientApp.csproj
+++ b/MCPClientApp/MCPClientApp.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.1" />
+  </ItemGroup>
+
+</Project>

--- a/MCPClientApp/Program.cs
+++ b/MCPClientApp/Program.cs
@@ -1,0 +1,18 @@
+using ModelContextProtocol.Client;
+
+// Start the local MCP server using stdio transport
+IMcpClient client = await McpClientFactory.CreateAsync(
+    new StdioClientTransport(new()
+    {
+        Command = "dotnet",
+        Arguments = ["run", "--project", "../MCPHostApp/MCPHostApp.csproj"],
+        Name = "Local MCP Server",
+    }));
+
+Console.WriteLine("Available tools:");
+var tools = await client.ListToolsAsync();
+foreach (var tool in tools)
+{
+    Console.WriteLine(tool);
+}
+

--- a/mcptesting.sln
+++ b/mcptesting.sln
@@ -4,6 +4,8 @@ VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MCPHostApp", "MCPHostApp\MCPHostApp.csproj", "{A5849411-C596-2087-E8DC-7FF5825A5844}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MCPClientApp", "MCPClientApp\MCPClientApp.csproj", "{ABB75CE2-2CC5-4EFF-A34C-A4EC9A8B38D8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -14,6 +16,10 @@ Global
 		{A5849411-C596-2087-E8DC-7FF5825A5844}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A5849411-C596-2087-E8DC-7FF5825A5844}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A5849411-C596-2087-E8DC-7FF5825A5844}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ABB75CE2-2CC5-4EFF-A34C-A4EC9A8B38D8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ABB75CE2-2CC5-4EFF-A34C-A4EC9A8B38D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ABB75CE2-2CC5-4EFF-A34C-A4EC9A8B38D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ABB75CE2-2CC5-4EFF-A34C-A4EC9A8B38D8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add MCPClientApp project with ModelContextProtocol dependency
- create basic client program that starts the host and lists tools
- update solution to include the new client project

## Testing
- `dotnet build mcptesting.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68650606e690832793ee617dfbabe037